### PR TITLE
Added authorized_keys functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Get an RSA PEM key pair.
 
 * `bits`: the size for the private key in bits. Default: **2048**.
 * `e`: the public exponent to use. Default: **65537**.
+* `openSSH`: an additional property called `openSSH` will be generated which allows you to add the generated public key to `authorized_keys`
 
 ## Installation
 

--- a/index.js
+++ b/index.js
@@ -17,8 +17,21 @@ module.exports = function (opts) {
     public: fix(forge.pki.publicKeyToRSAPublicKeyPem(keypair.publicKey, 72)),
     private: fix(forge.pki.privateKeyToPem(keypair.privateKey, 72))
   };
+  // if requested, generate the OpenSSH authorized_keys line
+  if(opts.openSSH) {
+    keypair.openSSH = genOpenSSH(keypair.public);
+  }
   return keypair;
 };
+
+// generates an OpenSSH "authorized_keys" string from an RSA key
+function genOpenSSH(rsaKey) {
+  var lines = rsaKey.replace('\r','').split('\n');
+  // strip first line and last two lines (begin/end, plus blank line)
+  lines.splice(0,1); // remove -----BEGIN RSA PRIVATE KEY-----
+  lines.splice(lines.length-2,2); // remove -----END RSA PRIVATE KEY----- & newline
+  return 'ssh-rsa ' + lines.join('') + ' ';
+}
 
 function fix (str) {
   return str.replace(/\r/g, '') + '\n'

--- a/test.js
+++ b/test.js
@@ -1,3 +1,4 @@
+var crypto = require('crypto');
 var keypair = require('./index.js');
 var test = require('tape');
 
@@ -7,5 +8,20 @@ test('keypair', function (t) {
   t.assert(/BEGIN RSA PRIVATE KEY/.test(pair.private), 'private header');
   t.ok(pair.public, 'public key');
   t.assert(/BEGIN RSA PUBLIC KEY/.test(pair.public), 'public header');
+  t.end();
+});
+
+test('test against crypto library', function(t) {
+  var pair = keypair();
+  var testString = 'Hello, world'
+  var encrypted = crypto.publicEncrypt(pair.public, new Buffer(testString));
+  var decrypted = crypto.privateDecrypt(pair.private, encrypted);
+  t.equal(decrypted.toString(), testString);
+  t.end();
+});
+
+test('ensure OpenSSH line is generated when the option is passed', function(t) {
+  var pair = keypair({openSSH: true});
+  t.ok(pair.openSSH, 'OpenSSH');
   t.end();
 });


### PR DESCRIPTION
Simply pass `openSSH` to opts as a truthy value and it will generate a line for OpenSSH. Have not tested it with an actual SSH system, should be double checked.
