### PR TITLE
fix:typescript: set default export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,3 +17,4 @@ export interface KeypairResults {
  * @param opts
  */
 export function keypair(opts?: KeypairOptions): KeypairResults;
+export default keypair;


### PR DESCRIPTION
javascript use `module.exports = function (opts) {` which is equivalent to default export in typescript; 

-keypair is not exported as named export in javascript 

in typescript if lib. is imported using:

- `import {keypair} form 'keypair'}` which cause "keypair.keypair is not a function" error
- `import * as keypair from 'keypair'` will throw typescript error; keypair is not a function
- `import keypair from 'keypair';` will result in 'keypair doesnot have default export' error;

this pull request export keypair as default export; i kept named export as is in case it was placed there for a future reason!