### PR TITLE
As Math.random always returns a number lower than 1, the return value…

### DIFF
--- a/index.js
+++ b/index.js
@@ -995,7 +995,7 @@ prng.create = function(plugin) {
       implemented with David G. Carta's optimization: with 32 bit math
       and without division (Public Domain). */
       var hi, lo, next;
-      var seed = Math.floor(Math.random() * 0xFFFF);
+      var seed = Math.floor(Math.random() * 0x10000);
       while(b.length() < needed) {
         lo = 16807 * (seed & 0xFFFF);
         hi = 16807 * (seed >> 16);
@@ -1008,7 +1008,7 @@ prng.create = function(plugin) {
         for(var i = 0; i < 3; ++i) {
           // throw in more pseudo random
           next = seed >>> (i << 3);
-          next ^= Math.floor(Math.random() * 0xFF);
+          next ^= Math.floor(Math.random() * 0x100);
           b.putByte(next & 0xFF);
         }
       }


### PR DESCRIPTION
… should be multiplied with the max value wanted plus 1.
If not the full range of values are not returned making the random values 1/256th less random.
Fell free to correct me, if I am wrong.