### PR TITLE
Fix type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,18 +3,20 @@
 // Definitions by: eskelter <https://github.com/eskelter>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
-export interface KeypairOptions {
-    bits?: number;
-    e?: number;
-}
-export interface KeypairResults {
-    public: string;
-    private: string;
+declare namespace keypair {
+    export interface KeypairOptions {
+        bits?: number;
+        e?: number;
+    }
+    export interface KeypairResults {
+        public: string;
+        private: string;
+    }
 }
 
 /**
  * Get an RSA PEM key pair.
  * @param opts
  */
-export function keypair(opts?: KeypairOptions): KeypairResults;
-export default keypair;
+declare function keypair(opts?: keypair.KeypairOptions): keypair.KeypairResults;
+export = keypair;


### PR DESCRIPTION
The current type definition requires `esModuleInterop: true` to work. Otherwise you get errors like: `TypeError: (0 , keypair_1.default) is not a function`

References:

- https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html - "Note that using export default in your .d.ts files requires esModuleInterop: true to work. If you can’t have esModuleInterop: true in your project, such as when you’re submitting a PR to Definitely Typed, you’ll have to use the export= syntax instead. This older syntax is harder to use but works everywhere."
- https://stackoverflow.com/questions/55910285/export-custom-type-definition-with-module-exports
- https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-function-d-ts.html

This change uses Declaration Merging and the `export =` syntax so it works with and without `esModuleInterop`.

```ts
import * as keypair from 'keypair';

const keys: keypair.KeypairResults = keypair();
```